### PR TITLE
Fix thread safety issues in F4DX_manager, F4IReader

### DIFF
--- a/Core/F4DX_manager.h
+++ b/Core/F4DX_manager.h
@@ -1,8 +1,11 @@
 #pragma once
 
 #include "F4IReader.h"
-#include <thread>
+
+#include <atomic>
 #include <chrono>
+#include <thread>
+#include <mutex>
 #include <string>
 
 /*
@@ -24,10 +27,10 @@ private:
 	///////////////
 
 	// D3D9 variables
-	bool bDraw = true;
+	std::atomic_bool bDraw = true;
 
 	// Init variables
-	bool bInit = false;
+	std::once_flag bInit;
 
 	// Object variables
 	F4IReader memReader;
@@ -64,8 +67,11 @@ public:
 
 	// Sets drawing conditions. true = drawing is enabled; false = drawing is disabled.
 	void setDraw(bool bDraw);
-	// Gets the draw conditions. true = functions calls from BMS to DirectX should be passed through; false = functions calls from BMS to DirectX should be ignored.
-	bool shouldDraw();
+
+	// Gets the draw conditions.
+	// true = functions calls from BMS to DirectX should be passed through;
+	// false = functions calls from BMS to DirectX should be ignored.
+	bool shouldDraw() const { return bDraw.load(std::memory_order_acquire); }
 
 	// Establishes 
 	void establishIO();

--- a/Core/F4IReader.h
+++ b/Core/F4IReader.h
@@ -12,7 +12,7 @@ protected:
 	// Member Variables
 	HANDLE m_hMapping = nullptr;
 	HANDLE m_hView = nullptr;
-	IntellivibeData *m_ivData = nullptr;
+	volatile IntellivibeData *m_ivData = nullptr;
 
 public:
 	// Public functions

--- a/F4D11Wrapper/F4D11Wrapper.vcxproj
+++ b/F4D11Wrapper/F4D11Wrapper.vcxproj
@@ -171,7 +171,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
       <TreatLinkerWarningAsErrors>true</TreatLinkerWarningAsErrors>
-      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>
       </ProgramDatabaseFile>
       <ProfileGuidedDatabase>$(OutDir)output\$(TargetName).pgd</ProfileGuidedDatabase>


### PR DESCRIPTION
- F4IReader: Make shared memory reads volatile

  `volatile` informs the compiler that the memory at the given addresses can
  change without our code doing anything.
  (This is exactly what happens with shared memory.)

- Use atomic loads and stores for `setDraw()`/`shouldDraw()`.

  Reading and writing a variable from multiple threads without atomic
  ops creates race conditions. On a related note,

- Use `std::call_once` to properly protect initEnvironment()

- Inline `shouldDraw()` in the header.

  It looks like `/GL` (whole program optimization) was already inlining
  `shouldDraw()`, but this should be more performant across a variety
  of optimization flags.

For more info on atomic ops, see
- https://www.youtube.com/watch?v=ZQFzMfHIxng
- https://assets.bitbashing.io/papers/concurrency-primer.pdf